### PR TITLE
Add OS X settings to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
     wdm (0.1.1)
 
 PLATFORMS
+  universal-darwin-19
   x86_64-linux
 
 DEPENDENCIES
@@ -99,4 +100,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   2.2.5
+   2.2.6


### PR DESCRIPTION
I guess this is the right thing to do? Online advice seems to be to keep Gemfile.lock in the repo, and updated. Not sure why the BUNDLED WITH version changes from 2.2.5 to 2.2.6, but I guess that's fine on linux too?