### PR TITLE
correct paragraph tags

### DIFF
--- a/learn.html
+++ b/learn.html
@@ -33,12 +33,12 @@ permalink: /learn.html
     </dl>
 
 <h1><a id="tutorials"></a>Tutorials</h1>
-    </p>If you like learning by example, then head over to the
+    <p>If you like learning by example, then head over to the
     <a href="tutorials/">tutorials</a> section of this site, which provides some
     general introductory material, followed by a number of more focussed tutorials
-    demonstrating how to generate and process tree sequences.
+    demonstrating how to generate and process tree sequences.</p>
     
-    Tutorials include examples of statistical analysis of simulated genomic data using
+    <p>Tutorials include examples of statistical analysis of simulated genomic data using
     <a href="https://tskit.dev/tskit">tskit</a> as well as advanced usage of genome
     simulation software such as <a href="https://tskit.dev/tskit">msprime</a>.</p>
 </div>


### PR DESCRIPTION
Sorry - just noticed that the `h1` isn't centred, weirdly - and my tags didn't match. This might not correct the centring, but probably best to match the tags properly