### PR TITLE
Fix tskit version number

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -217,7 +217,7 @@ jobs:
         run: |
           venv-latest/bin/activate
           cd docs
-          make
+          make dist
 
       - name: Copy docs
         if: steps.docs-cache.outputs.cache-hit != 'true'
@@ -228,6 +228,7 @@ jobs:
       - name: Checkout latest stable tag
         if: steps.docs-cache.outputs.cache-hit != 'true'
         run: |
+          git stash
           git fetch --tags --recurse-submodules=no
           git checkout `git tag --list --sort=taggerdate | grep -vi "[baC]" | tail -n1`
           git submodule update --init --recursive
@@ -251,7 +252,7 @@ jobs:
           rm -rf docs/_build
           venv-stable/bin/activate
           cd docs
-          make
+          make dist
 
       - name: Copy docs
         if: steps.docs-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Fixes #63 
Seems the msprime and tskit makefiles differ in that we need to `make dist` for tskit. 