### PR TITLE
latest to stable link

### DIFF
--- a/_software/pyslim.md
+++ b/_software/pyslim.md
@@ -6,7 +6,7 @@ name: pyslim
 #description: 
 #repo_url: 
 gh_org: tskit-dev
-docs_url: https://tskit.dev/pyslim/docs/latest
+docs_url: https://tskit.dev/pyslim/docs/stable
 category: analyse
 permalink: /pyslim
 python_package: pyslim


### PR DESCRIPTION
The docs were linked to `latest` before; this changes the link to `stable` (I think). I won't merge this pre-emptively, this time =)