### PR TITLE
tskit footer logo needs some space below

### DIFF
--- a/assets/src/sass/components/_footer.scss
+++ b/assets/src/sass/components/_footer.scss
@@ -24,6 +24,7 @@
 
 .footer__logo {
   display: inline-block;
+  margin-bottom: 2rem;
 
   .icon--logo {
     max-width: 100%;


### PR DESCRIPTION
When the site is narrow, the tskit logo and the list of 4 things in the footer are stacked and way too close. Feel free to do some other tweak. This looks much better when I add this CSS line in Firefox developer mode.