### PR TITLE
Add .org to Phyloseminar

### DIFF
--- a/_resources/wohns-phyloseminar.md
+++ b/_resources/wohns-phyloseminar.md
@@ -3,7 +3,7 @@ type: video
 youtube-id: YrZTKjLzZY0
 who: Wilder Wohns
 year: 2020
-where: Phyloseminar
+where: Phyloseminar.org
 title: Tree sequence fundamentals
 timestamp: 2020-04-08
 ---

--- a/_resources/wong-phyloseminar.md
+++ b/_resources/wong-phyloseminar.md
@@ -3,7 +3,7 @@ type: video
 youtube-id: yB4uSle66Pw
 who: Yan Wong
 year: 2020
-where: Phyloseminar
+where: Phyloseminar.org
 title: Tree sequences and inference
 timestamp: 2020-05-22
 ---


### PR DESCRIPTION
When the talk was for a website like phyloseminar, rather than at a conference, I think it reads better to have the web URL.

I think it would also be nice to turn the `where` into a link, but I don't know if that's allowed in the specs, so I haven't tried it. Do you know @benjeffery ?