### PR TITLE
add redirect also for pyslim

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -465,6 +465,8 @@ jobs:
         if: steps.docs-cache.outputs.cache-hit != 'true'
         run: |
           venv-latest/bin/activate
+          # Install jsonschema for bugfix
+          pip install jsonschema[format-nongpl]==4.17.3
           export PATH=$PATH:$PWD/SLiM/Release
           cd docs
           # don't re-generate these which require tricky prerequisites (inkscape, xmlstarlet)
@@ -514,6 +516,8 @@ jobs:
         run: |
           rm -rf docs/_build
           venv-stable/bin/activate
+          # Install jsonschema for bugfix
+          pip install jsonschema[format-nongpl]==4.17.3
           export PATH=$PWD/SLiM/Stable:$PATH
           cd docs
           # don't re-generate these which require tricky prerequisites (inkscape, xmlstarlet)

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -635,6 +635,7 @@ jobs:
           echo "<meta http-equiv=\"Refresh\" content=\"0; url=/msprime/docs/stable\" />" > site/msprime/docs/index.html
           echo "<meta http-equiv=\"Refresh\" content=\"0; url=/tsinfer/docs/stable\" />" > site/tsinfer/docs/index.html
           echo "<meta http-equiv=\"Refresh\" content=\"0; url=/tskit/docs/stable\" />" > site/tskit/docs/index.html
+          echo "<meta http-equiv=\"Refresh\" content=\"0; url=/pyslim/docs/stable\" />" > site/pyslim/docs/index.html
 
       - name: List site contents
         run: |


### PR DESCRIPTION
@bhaller asks:
```
I notice that on https://tskit.dev/software/ the “Documentation” links are a bit inconsistent.  In particular, tskit’s docs are https://tskit.dev/tskit/docs/, msprime’s docs are https://tskit.dev/msprime/docs/, tsinfer’s docs are https://tskit.dev/tsinfer/docs/ – but pyslim’s docs are https://tskit.dev/pyslim/docs/stable, and indeed, https://tskit.dev/pyslim/docs/ does not even seem to work (!), but gives a -404.
```

This ought to fix that?