### PR TITLE
Add the ARG tute to "resources"

### DIFF
--- a/_resources/args.md
+++ b/_resources/args.md
@@ -1,0 +1,11 @@
+---
+type: tutorial
+tutorial_id: args
+title: ARGs as tree sequences
+timestamp: 2023-11-10
+---
+The `tskit` library provides a convenient way to encode and work with
+ancestral recombination graphs (ARGs). This tutorial introduces the
+concept of "full ARGs" in tskit, the link between these ARGs and
+more simplified graphical representations, and how to use `tskit`
+to work with inheritance graphs in general.


### PR DESCRIPTION
Now that the ARG tutorial is basically complete, it might be nice to add it to the resources page.

OTOH we might want to promote this only after we have constructed the ["ARG API"](https://github.com/tskit-dev/tskit/discussions/2869) for tskit.