### PR TITLE
Add named anchors and a JS "hack"

### DIFF
--- a/assets/src/js/main.js
+++ b/assets/src/js/main.js
@@ -34,3 +34,9 @@ window.switch_filter = (category) => {
     $('[data-r-type="'+category+'"]').show()
   }
 }
+
+/* allow a url like learn/?filter=paper#tutorials-publications-videos to show papers only */
+const urlParams = new URLSearchParams(window.location.search);
+if (urlParams.has('filter')) {
+  window.switch_filter(urlParams.get('filter'));
+}

--- a/learn.html
+++ b/learn.html
@@ -9,7 +9,7 @@ permalink: /learn/
     <div class="container">
         <div class="row">
             <div class="col-md-8 col-lg-6">
-                <h2 class="hero__heading">
+                <h2 id="what-is" class="hero__heading">
                     What is a tree sequence?
                 </h2>
                 <div class="hero__content wysiwyg">
@@ -40,7 +40,7 @@ permalink: /learn/
             <div class="col-lg-4">
                 <!-- START: card -->
                 <a href="{{ 'tutorials/what_is.html#sec-what-is-ancestry' | relative_url }}" class="card card--type-2">
-                    <h4 class="card__heading">
+                    <h4 id="genetic-ancestry" class="card__heading">
                         A full record of genetic ancestry
                     </h4>
                     <p class="card__text">
@@ -58,7 +58,7 @@ permalink: /learn/
             <div class="col-lg-4">
                 <!-- START: card -->
                 <a href="{{ 'tutorials/what_is.html#sec-what-is-dna-data' | relative_url }}" class="card card--type-2">
-                    <h4 class="card__heading">
+                    <h4 id="DNA-encoding" class="card__heading">
                         An encoding of DNA data
                     </h4>
                     <p class="card__text">
@@ -76,7 +76,7 @@ permalink: /learn/
             <div class="col-lg-4">
                 <!-- START: card -->
                 <a href="{{ 'tutorials/what_is.html#sec-what-is-analysis' | relative_url }}" class="card card--type-2">
-                    <h4 class="card__heading">
+                    <h4 id="efficient-analysis" class="card__heading">
                         An efficient analysis framework
                     </h4>
                     <p class="card__text">
@@ -101,7 +101,7 @@ permalink: /learn/
     <div class="container">
         <div class="row">
             <div class="col-md-8">
-                <h3 class="section__heading">
+                <h3 id="tutorials-publications-videos" class="section__heading">
                     Browse tutorials, publications and videos:
                 </h3>
             </div>


### PR DESCRIPTION
This allows us to show a list that is restricted to e.g. papers by using cgi-like params:

```
learn/?filter=paper#tutorials-publications-videos
```

This seems like a big enough win to counter the slight `URLSearchParams` hack. What do you think @benjeffery ?