### PR TITLE
tweak wording to msprime paper

### DIFF
--- a/_resources/kelleher2016.md
+++ b/_resources/kelleher2016.md
@@ -3,7 +3,8 @@ type: paper
 doi: 10.1371/journal.pcbi.1004842
 timestamp: 2016-04-04
 ---
-This is where it all started. Here we introduce the
+This is where the tree sequence data structure
+was first described. Here we introduce the
 [msprime](/software/msprime.html) coalescent simulator and
 the core algorithms and data structures that would later
 be separated out into [tskit](software/tskit.html).


### PR DESCRIPTION
In the interest of having https://tskit.dev/learn/ be somewhat inclusive of general work on ARGs, it's come to my attention that the wording on the msprime paper ("where it all started") was less precise than we'd like. So, this is tweaking that.