### PR TITLE
remove tweak since it's in pyslim/docs/_config.yml

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -500,8 +500,6 @@ jobs:
           venv-latest/bin/activate
           export PATH=$PWD/SLiM/Stable:$PATH
           cd docs
-          # A sphinx-book-theme breaking change needs this
-          sed -i '/html_theme_options:/a\ \ \ \ \ navigation_with_keys: False' _config.yml
           
           # don't re-generate these which require tricky prerequisites (inkscape, xmlstarlet)
           touch _static/{pedigree0.svg,pedigree1.svg,pedigree2.svg,pedigree_recapitate.svg,pedigree_simplify.svg,pedigree_mutate.svg}


### PR DESCRIPTION
Building the pyslim docs failed with
```
  File "/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/site-packages/yaml/parser.py", line 438, in parse_block_mapping_key
    raise ParserError("while parsing a block mapping", self.marks[-1],
yaml.parser.ParserError: while parsing a block mapping
  in "<unicode string>", line 29, column 5:
        extra_extensions:
        ^
expected <block end>, but found '<block mapping start>'
  in "<unicode string>", line 41, column 6:
         navigation_with_keys: False
         ^
make: *** [Makefile:15: dist] Error 1
Updated 14 paths from the index
```
and looking at `.github/workflows/build-deploy.yml` we have
```
          cd docs
          # A sphinx-book-theme breaking change needs this
          sed -i '/html_theme_options:/a\ \ \ \ \ navigation_with_keys: False' _config.yml
```
I think the error is because of the wrong number of spaces. But first I'm trying deleting this, since the line `navigation_with_keys: false` is in pyslim's `docs/_config.yml` already.