### PR TITLE
Update logo URL in SLiM documentation

### DIFF
--- a/_software/SLiM.md
+++ b/_software/SLiM.md
@@ -6,7 +6,7 @@ gh_org: MesserLab
 homepage: https://messerlab.org/slim/
 docs_url: http://benhaller.com/slim/SLiM_Manual.pdf
 publication: https://doi.org/10.1093/molbev/msy228
-logo: https://i.imgur.com/x54xJoK.jpg
+logo: https://github.com/MesserLab/SLiM/blob/master/QtSLiM/icons/AppIcon64.svg
 priority: 10
 force_show_title: true
 category: simulate


### PR DESCRIPTION
Currently looks like this, which isn't great!

<img width="495" height="368" alt="Screenshot 2025-12-02 at 15 59 36" src="https://github.com/user-attachments/assets/1dc9ef2e-789a-43c9-b5b4-55e0f7af30d0" />
