### PR TITLE
Migrate tszip latest docs build to shared composite action

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -201,6 +201,7 @@ jobs:
 
           - package: tskit
             additional-apt-packages: doxygen
+            pre-build-command: cd docs/doxygen && doxygen
             pyproject-directory: python
             cache-version: v18
 


### PR DESCRIPTION
Excludes tszip latest from the legacy build-docs matrix and adds a dedicated build-docs-tszip-latest job that checks out tszip at main, caches by commit SHA, and delegates to the build-docs composite action from tskit-dev/.github.

tszip stable and all other packages remain on the legacy build path.